### PR TITLE
Add Exa search and scraper integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supported SERP provider:
   * [Tavily](https://tavily.com/)
   * [You.com](https://you.com/)
   * [Brave](https://brave.com)
+  * [Exa](https://exa.ai)
 
 
 Example to use scraper
@@ -40,6 +41,7 @@ Supported Scraper provider
   * Browserless
   * Zyte
   * Crawlbase
+  * [Exa](https://exa.ai)
 
 # TODO
 

--- a/src/surfhub/scraper/__init__.py
+++ b/src/surfhub/scraper/__init__.py
@@ -3,6 +3,7 @@ from .local import LocalScraper
 from .browserless import BrowserlessScraper
 from .zyte import ZyteScraper
 from .crawlbase import CrawlbaseScraper
+from .exa import ExaScraper
 
 def get_scraper(provider, api_key=None, **kwargs) -> Scraper:
     if provider == "local":
@@ -13,5 +14,7 @@ def get_scraper(provider, api_key=None, **kwargs) -> Scraper:
         return ZyteScraper(api_key=api_key, **kwargs)
     elif provider == "crawlbase":
         return CrawlbaseScraper(api_key=api_key, **kwargs)
+    elif provider == "exa":
+        return ExaScraper(api_key=api_key, **kwargs)
 
     raise ValueError("Unknown scraper provider")

--- a/src/surfhub/scraper/exa.py
+++ b/src/surfhub/scraper/exa.py
@@ -1,0 +1,37 @@
+import json
+from .model import BaseScraper, ScraperResponse
+import httpx
+
+
+class ExaScraper(BaseScraper):
+    """
+    Scraper that uses Exa Contents API (https://exa.ai)
+    Fetches cleaned page text for a given URL via POST /contents.
+    Auth: x-api-key header.
+    """
+    default_api_url = "https://api.exa.ai/contents"
+
+    def prepare_request(self, url: str, options=None) -> httpx.Request:
+        return httpx.Request(
+            "POST",
+            self.api_url,
+            headers={
+                "x-api-key": self.api_key,
+                "Content-Type": "application/json",
+            },
+            content=json.dumps({
+                "ids": [url],
+                "text": True,
+            }).encode(),
+        )
+
+    def parse_response(self, url: str, resp: httpx.Response) -> ScraperResponse:
+        data = resp.json()
+        results = data.get("results", [])
+        text = results[0].get("text", "") if results else ""
+        final_url = results[0].get("url", url) if results else url
+        return ScraperResponse(
+            content=text.encode("utf-8"),
+            final_url=final_url,
+            status_code=resp.status_code,
+        )

--- a/src/surfhub/serper/__init__.py
+++ b/src/surfhub/serper/__init__.py
@@ -7,6 +7,7 @@ from .tavily import Tavily
 from .serpapi import SerpApi
 from .you import YouSearch
 from .brave import BraveSearch
+from .exa import ExaSearch
 from surfhub.cache.base import Cache
 
 
@@ -39,5 +40,8 @@ def get_serper(provider, cache: Cache=None, api_key=None, **kwargs) -> BaseSerpe
     
     if provider == "brave":
         return BraveSearch(cache=cache, **kwargs)
-    
+
+    if provider == "exa":
+        return ExaSearch(cache=cache, **kwargs)
+
     raise ValueError(f"Unknown provider: {provider}")

--- a/src/surfhub/serper/exa.py
+++ b/src/surfhub/serper/exa.py
@@ -1,0 +1,64 @@
+from typing import List, Optional
+from surfhub.serper.model import SerpResult, BaseSerper, SerpResponse
+import httpx
+
+
+class ExaSearch(BaseSerper):
+    """
+    Search via Exa API (https://exa.ai)
+    Uses neural/keyword/auto search and returns structured results.
+    Auth: x-api-key header.
+    """
+    default_api_url = "https://api.exa.ai/search"
+
+    def get_serp_params(self, query, page=None, num=None, options=None):
+        params = {
+            "query": query,
+            "type": "auto",
+        }
+
+        if num is not None:
+            params["numResults"] = num
+
+        if options:
+            if options.date_start:
+                params["startPublishedDate"] = options.date_start + "T00:00:00.000Z"
+            if options.date_end:
+                params["endPublishedDate"] = options.date_end + "T23:59:59.999Z"
+            if options.extra_options:
+                params.update(options.extra_options)
+
+        return params
+
+    def _headers(self):
+        return {
+            "x-api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+    def serp(self, query: str, page=None, num=None, options=None):
+        params = self.get_serp_params(query, page, num, options)
+        resp = httpx.post(self.endpoint, json=params, headers=self._headers(), timeout=self.timeout)
+        resp.raise_for_status()
+        items = self.parse_result(resp.json())
+        return SerpResponse(items=items, cached=False)
+
+    async def async_serp(self, query: str, page=None, num=None, options=None):
+        params = self.get_serp_params(query, page, num, options)
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            resp = await client.post(self.endpoint, json=params, headers=self._headers())
+            resp.raise_for_status()
+            items = self.parse_result(resp.json())
+        return SerpResponse(items=items, cached=False)
+
+    def parse_result(self, resp) -> List[SerpResult]:
+        results = resp.get("results", [])
+        return [
+            SerpResult(
+                title=r.get("title", ""),
+                link=r.get("url", ""),
+                snippet=r.get("text") or r.get("summary", ""),
+                prefix=""
+            )
+            for r in results
+        ]

--- a/tests/scaper/test_exa.py
+++ b/tests/scaper/test_exa.py
@@ -1,0 +1,86 @@
+import respx
+import httpx
+import pytest
+from surfhub.scraper.exa import ExaScraper
+
+EXA_CONTENTS_URL = "https://api.exa.ai/contents"
+
+
+def test_exa_scraper_basic():
+    with respx.mock:
+        respx.post(EXA_CONTENTS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "url": "https://example.com",
+                            "text": "This is the page content.",
+                        }
+                    ]
+                },
+            )
+        )
+        scraper = ExaScraper(api_key="test_key")
+        resp = scraper.scrape("https://example.com")
+        assert resp.text() == "This is the page content."
+        assert resp.final_url == "https://example.com"
+        assert resp.status_code == 200
+
+
+def test_exa_scraper_auth_header():
+    with respx.mock:
+        route = respx.post(EXA_CONTENTS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"results": [{"url": "https://example.com", "text": "content"}]},
+            )
+        )
+        scraper = ExaScraper(api_key="my_secret_key")
+        scraper.scrape("https://example.com")
+        assert route.calls[0].request.headers["x-api-key"] == "my_secret_key"
+
+
+def test_exa_scraper_request_body():
+    with respx.mock:
+        route = respx.post(EXA_CONTENTS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"results": [{"url": "https://example.com", "text": "content"}]},
+            )
+        )
+        scraper = ExaScraper(api_key="test_key")
+        scraper.scrape("https://example.com")
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body["ids"] == ["https://example.com"]
+        assert body["text"] is True
+
+
+def test_exa_scraper_empty_results():
+    with respx.mock:
+        respx.post(EXA_CONTENTS_URL).mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        scraper = ExaScraper(api_key="test_key")
+        resp = scraper.scrape("https://example.com")
+        assert resp.text() == ""
+        assert resp.final_url == "https://example.com"
+
+
+@pytest.mark.anyio
+async def test_exa_scraper_async():
+    with respx.mock:
+        respx.post(EXA_CONTENTS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"url": "https://async.example.com", "text": "async content"}
+                    ]
+                },
+            )
+        )
+        scraper = ExaScraper(api_key="test_key")
+        resp = await scraper.async_scrape("https://async.example.com")
+        assert resp.text() == "async content"

--- a/tests/scaper/test_factory.py
+++ b/tests/scaper/test_factory.py
@@ -1,6 +1,7 @@
 from surfhub.scraper import get_scraper
 from surfhub.scraper.local import LocalScraper
 from surfhub.scraper.browserless import BrowserlessScraper
+from surfhub.scraper.exa import ExaScraper
 
 def test_factory():
     scraper = get_scraper('local')
@@ -8,3 +9,6 @@ def test_factory():
 
     scraper = get_scraper('browserless')
     assert isinstance(scraper, BrowserlessScraper)
+
+    scraper = get_scraper('exa', api_key='test_key')
+    assert isinstance(scraper, ExaScraper)

--- a/tests/serper/test_exa.py
+++ b/tests/serper/test_exa.py
@@ -1,0 +1,114 @@
+import respx
+import httpx
+import pytest
+from surfhub.serper.exa import ExaSearch
+from surfhub.serper.model import SerpRequestOptions, TimeRange
+
+EXA_URL = "https://api.exa.ai/search"
+
+
+def test_exa_basic():
+    with respx.mock:
+        respx.post(EXA_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "title": "Example Result",
+                            "url": "https://example.com",
+                            "text": "Some page content",
+                        }
+                    ]
+                },
+            )
+        )
+        serp = ExaSearch(api_key="test_key")
+        resp = serp.serp("test query")
+        assert len(resp.items) == 1
+        assert resp.items[0].title == "Example Result"
+        assert resp.items[0].link == "https://example.com"
+        assert resp.items[0].snippet == "Some page content"
+
+
+def test_exa_auth_header():
+    with respx.mock:
+        route = respx.post(EXA_URL).mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        serp = ExaSearch(api_key="my_secret_key")
+        serp.serp("query")
+        assert route.calls[0].request.headers["x-api-key"] == "my_secret_key"
+
+
+def test_exa_num_results():
+    serp = ExaSearch(api_key="test_key")
+    params = serp.get_serp_params("query", num=5)
+    assert params["numResults"] == 5
+
+
+def test_exa_date_start():
+    serp = ExaSearch(api_key="test_key")
+    options = SerpRequestOptions(date_start="2024-01-01")
+    params = serp.get_serp_params("query", options=options)
+    assert params["startPublishedDate"] == "2024-01-01T00:00:00.000Z"
+    assert "endPublishedDate" not in params
+
+
+def test_exa_date_end():
+    serp = ExaSearch(api_key="test_key")
+    options = SerpRequestOptions(date_end="2024-12-31")
+    params = serp.get_serp_params("query", options=options)
+    assert params["endPublishedDate"] == "2024-12-31T23:59:59.999Z"
+    assert "startPublishedDate" not in params
+
+
+def test_exa_date_range():
+    serp = ExaSearch(api_key="test_key")
+    options = SerpRequestOptions(date_start="2024-01-01", date_end="2024-12-31")
+    params = serp.get_serp_params("query", options=options)
+    assert params["startPublishedDate"] == "2024-01-01T00:00:00.000Z"
+    assert params["endPublishedDate"] == "2024-12-31T23:59:59.999Z"
+
+
+def test_exa_extra_options():
+    serp = ExaSearch(api_key="test_key")
+    options = SerpRequestOptions(extra_options={"type": "neural", "includeDomains": ["example.com"]})
+    params = serp.get_serp_params("query", options=options)
+    assert params["type"] == "neural"
+    assert params["includeDomains"] == ["example.com"]
+
+
+def test_exa_default_type():
+    serp = ExaSearch(api_key="test_key")
+    params = serp.get_serp_params("query")
+    assert params["type"] == "auto"
+
+
+def test_exa_empty_results():
+    with respx.mock:
+        respx.post(EXA_URL).mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        serp = ExaSearch(api_key="test_key")
+        resp = serp.serp("query")
+        assert resp.items == []
+
+
+@pytest.mark.anyio
+async def test_exa_async():
+    with respx.mock:
+        respx.post(EXA_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"title": "Async Result", "url": "https://async.example.com", "text": "content"}
+                    ]
+                },
+            )
+        )
+        serp = ExaSearch(api_key="test_key")
+        resp = await serp.async_serp("async query")
+        assert len(resp.items) == 1
+        assert resp.items[0].title == "Async Result"

--- a/tests/serper/test_factory.py
+++ b/tests/serper/test_factory.py
@@ -3,6 +3,7 @@ from surfhub.serper.google import GoogleCustomSearch
 from surfhub.serper.valueserp import ValueSerp
 from surfhub.serper.you import YouSearch
 from surfhub.serper.brave import BraveSearch
+from surfhub.serper.exa import ExaSearch
 
 def test_factory():
     serp = get_serper("google")
@@ -16,3 +17,6 @@ def test_factory():
 
     serp = get_serper("brave")
     assert isinstance(serp, BraveSearch)
+
+    serp = get_serper("exa")
+    assert isinstance(serp, ExaSearch)


### PR DESCRIPTION
## Summary
This PR adds support for [Exa](https://exa.ai) as both a SERP provider and web scraper, expanding the available search and content extraction options in surfhub.

## Key Changes

### Search Integration (ExaSearch)
- Added `ExaSearch` class implementing the Exa neural/keyword search API
- Supports configurable search types (neural, keyword, auto)
- Implements date range filtering via `date_start` and `date_end` options
- Supports custom parameters through `extra_options`
- Includes both synchronous (`serp`) and asynchronous (`async_serp`) methods
- Authenticates via `x-api-key` header

### Scraper Integration (ExaScraper)
- Added `ExaScraper` class using Exa's Contents API for page content extraction
- Fetches cleaned text content from URLs
- Supports both synchronous (`scrape`) and asynchronous (`async_scrape`) methods
- Returns structured response with content, final URL, and status code

### Factory Updates
- Updated `get_serper()` factory to support `"exa"` provider
- Updated `get_scraper()` factory to support `"exa"` provider
- Updated README with Exa in supported providers list

### Test Coverage
- Added comprehensive test suite for `ExaSearch` covering:
  - Basic search functionality and result parsing
  - Authentication header validation
  - Parameter handling (num_results, date ranges)
  - Extra options support
  - Empty results handling
  - Async search operations
- Added comprehensive test suite for `ExaScraper` covering:
  - Basic scraping functionality
  - Authentication header validation
  - Request body structure validation
  - Empty results handling
  - Async scraping operations
- Updated factory tests to verify Exa provider integration

## Implementation Details
- Both classes follow the existing base class patterns (`BaseSerper` and `BaseScraper`)
- Date parameters are automatically formatted to ISO 8601 with appropriate time boundaries (00:00:00 for start, 23:59:59 for end)
- Default search type is set to "auto" for intelligent query handling
- Proper error handling with `raise_for_status()` on HTTP responses

https://claude.ai/code/session_01Waejg3Qh4JvzXDHszKu3dd