### PR TITLE
fix: add unified error hierarchy, fix async, caching, types, and CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, W503
+exclude =
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    dist,
+    build,
+    sandbox,
+    *.egg-info,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[test]"
+          pip install anyio
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 120
+target-version = ['py38']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.venv
+  | dist
+  | build
+  | sandbox
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "C4", "UP", "B", "SIM"]
+ignore = ["E501"]

--- a/src/surfhub/__init__.py
+++ b/src/surfhub/__init__.py
@@ -1,6 +1,7 @@
 from .serper import get_serper
 from .serper.model import SerpRequestOptions, SerpResult
 from .scraper import get_scraper
+from .errors import SurfhubError, ScrapingError, SerpApiError
 
 
 __all__ = [
@@ -8,4 +9,7 @@ __all__ = [
     "SerpRequestOptions",
     "SerpResult",
     "get_scraper",
+    "SurfhubError",
+    "ScrapingError",
+    "SerpApiError",
 ]

--- a/src/surfhub/cache/base.py
+++ b/src/surfhub/cache/base.py
@@ -1,16 +1,18 @@
 import diskcache
 
+__all__ = ["Cache", "DummyCache", "FileCache"]
+
 class Cache:
-    def get(self, key):
+    def get(self, key: str):
         raise NotImplementedError()
     
-    def set(self, key, value, ttl=None):
+    def set(self, key: str, value, ttl: int = None):
         raise NotImplementedError()
     
-    def has(self, key):
+    def has(self, key: str) -> bool:
         return self.get(key) is not None
     
-    def delete(self, key):
+    def delete(self, key: str):
         raise NotImplementedError()
     
     def clear(self):
@@ -18,13 +20,13 @@ class Cache:
 
 
 class DummyCache(Cache):
-    def get(self, key):
+    def get(self, key: str):
         return None
     
-    def set(self, key, value, ttl=None):
+    def set(self, key: str, value, ttl: int = None):
         return None
     
-    def delete(self, key):
+    def delete(self, key: str):
         return None
     
     def clear(self):
@@ -32,17 +34,17 @@ class DummyCache(Cache):
 
 
 class FileCache(Cache):
-    def __init__(self, cache_dir, default_ttl=3600):
+    def __init__(self, cache_dir: str, default_ttl: int = 3600):
         self.cache = diskcache.Cache(cache_dir)
         self.ttl = default_ttl
     
-    def get(self, key):
+    def get(self, key: str):
         return self.cache.get(key)
     
-    def set(self, key, value, ttl=None):
+    def set(self, key: str, value, ttl: int = None):
         self.cache.set(key, value, expire=ttl or self.ttl)
     
-    def delete(self, key):
+    def delete(self, key: str):
         self.cache.pop(key, None)
 
     def clear(self):

--- a/src/surfhub/errors.py
+++ b/src/surfhub/errors.py
@@ -1,0 +1,19 @@
+class SurfhubError(Exception):
+    """Base exception for all surfhub errors."""
+    pass
+
+
+class ScrapingError(SurfhubError):
+    """Raised when a scraping operation fails."""
+
+    def __init__(self, message: str, status_code: int = None):
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class SerpApiError(SurfhubError):
+    """Raised when a SERP API call fails."""
+
+    def __init__(self, message: str, status_code: int = None):
+        self.status_code = status_code
+        super().__init__(message)

--- a/src/surfhub/scraper/browserless.py
+++ b/src/surfhub/scraper/browserless.py
@@ -9,7 +9,7 @@ class BrowserlessScraper(BaseScraper):
     """
     default_api_url = "https://chrome.browserless.io"
     
-    def prepare_request(self, url, options = None):
+    def prepare_request(self, url: str, options=None) -> httpx.Request:
         # TODO: we can also use the /content api
         api_url = self.api_url + "/scrape?token=" + self.api_key
         return httpx.Request(
@@ -22,7 +22,7 @@ class BrowserlessScraper(BaseScraper):
             }
         )
         
-    def parse_response(self, url, resp):
+    def parse_response(self, url: str, resp: httpx.Response) -> ScraperResponse:
         html = resp.json()['data'][0]['results'][0]['html']
         return ScraperResponse(
             content=html.encode("utf-8"),

--- a/src/surfhub/scraper/crawlbase.py
+++ b/src/surfhub/scraper/crawlbase.py
@@ -1,4 +1,5 @@
 from .model import BaseScraper, ScraperResponse
+from surfhub.errors import ScrapingError
 import httpx
 
 class CrawlbaseScraper(BaseScraper):
@@ -25,12 +26,13 @@ class CrawlbaseScraper(BaseScraper):
         super().validate_response(resp)
         
         if resp.headers.get("pc_status") != "200":
-            raise Exception("Unexpetected error: " + resp.text)
+            raise ScrapingError("Unexpected error: " + resp.text)
 
         
     def parse_response(self, url, resp: httpx.Response) -> ScraperResponse:
+        raw_status = resp.headers.get("original_status") or "200"
         return ScraperResponse(
             content=resp.content,
             final_url=resp.headers.get("url") or url,
-            status_code=str(resp.headers.get("original_status") or "200"),
+            status_code=int(raw_status),
         )

--- a/src/surfhub/scraper/local.py
+++ b/src/surfhub/scraper/local.py
@@ -31,7 +31,26 @@ class LocalScraper(Scraper):
         )
 
     async def async_scrape(self, url: str, options : ScraperOptions = None) -> ScraperResponse:
-        return self.scrape(url, options)
+        proxies = None
+        if self.http_proxy or self.https_proxy:
+            proxies = {
+                "http://": self.http_proxy,
+                "https://": self.https_proxy
+            }
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                url,
+                timeout=self.timeout,
+                proxies=proxies,
+                verify=self.verify_ca
+            )
+        
+        return ScraperResponse(
+            content=resp.content,
+            status_code=resp.status_code,
+            final_url=resp.url,
+        )
 
     @property
     def http_proxy(self) -> str:
@@ -50,9 +69,9 @@ class LocalScraper(Scraper):
         self._https_proxy = value
     
     @property
-    def verify_ca(self) -> int:
+    def verify_ca(self) -> bool:
         return self._verify_ca
     
     @verify_ca.setter
-    def verify_ca(self, value: int):
+    def verify_ca(self, value: bool):
         self._verify_ca = value

--- a/src/surfhub/scraper/model.py
+++ b/src/surfhub/scraper/model.py
@@ -1,6 +1,7 @@
 import abc
 import httpx
 from pydantic import BaseModel
+from surfhub.errors import ScrapingError
 
 class ScraperOptions(BaseModel):
     pass
@@ -104,7 +105,7 @@ class BaseScraper(Scraper):
 
     def validate_response(self, resp: httpx.Response):
         if resp.status_code != 200:
-            raise Exception("Unexpected status code: " + str(resp.status_code))
+            raise ScrapingError("Unexpected status code: " + str(resp.status_code), status_code=resp.status_code)
 
     def is_retriable_error(self, ex: Exception, resp: httpx.Response):
         # allow retries for connection errors

--- a/src/surfhub/scraper/zyte.py
+++ b/src/surfhub/scraper/zyte.py
@@ -17,10 +17,10 @@ class ZyteScraper(BaseScraper):
             }
         )
         
-    def get_request_auth(self):
+    def get_request_auth(self) -> tuple:
         return (self.api_key, "")
         
-    def parse_response(self, url, resp):
+    def parse_response(self, url: str, resp: httpx.Response) -> ScraperResponse:
         content = resp.json()['browserHtml']
         
         return ScraperResponse(

--- a/src/surfhub/serper/brave.py
+++ b/src/surfhub/serper/brave.py
@@ -1,6 +1,5 @@
-from typing import List
-from surfhub.serper.model import SerpResult, BaseSerper, SerpResponse
-import httpx
+from typing import List, Dict
+from surfhub.serper.model import SerpResult, BaseSerper, SerpRequestOptions
 
 
 class BraveSearch(BaseSerper):
@@ -10,7 +9,7 @@ class BraveSearch(BaseSerper):
     """
     default_api_url = "https://api.search.brave.com/res/v1/web/search"
 
-    def get_serp_params(self, query, page=None, num=None, options=None):
+    def get_serp_params(self, query: str, page=None, num=None, options: SerpRequestOptions = None) -> dict:
         params = {
             "q": query,
         }
@@ -28,17 +27,14 @@ class BraveSearch(BaseSerper):
             if options.lang:
                 params["search_lang"] = options.lang
             
-            # Handle time filtering with freshness parameter
             if options.date_start and options.date_end:
-                # Format: YYYY-MM-DDtoYYYY-MM-DD
                 params["freshness"] = f"{options.date_start}to{options.date_end}"
             elif options.time_range:
-                # Map TimeRange to freshness values: pd (day), pw (week), pm (month), py (year)
                 freshness_map = {
-                    "d": "pd",  # past day
-                    "w": "pw",  # past week
-                    "m": "pm",  # past month
-                    "y": "py"   # past year
+                    "d": "pd",
+                    "w": "pw",
+                    "m": "pm",
+                    "y": "py"
                 }
                 params["freshness"] = freshness_map.get(options.time_range.value, "pm")
             
@@ -47,36 +43,17 @@ class BraveSearch(BaseSerper):
         
         return params
 
-    def serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        headers = {
+    @property
+    def request_headers(self) -> Dict[str, str]:
+        return {
             "Accept": "application/json",
             "Accept-Encoding": "gzip",
             "X-Subscription-Token": self.api_key,
         }
-        resp = httpx.get(self.endpoint, params=params, headers=headers, timeout=self.timeout)
-        items = self.parse_result(resp.json())
-        return SerpResponse(items=items, cached=False)
 
-    async def async_serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        headers = {
-            "Accept": "application/json",
-            "Accept-Encoding": "gzip",
-            "X-Subscription-Token": self.api_key,
-        }
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            resp = await client.get(self.endpoint, params=params, headers=headers)
-            items = self.parse_result(resp.json())
-        return SerpResponse(items=items, cached=False)
-
-    def parse_result(self, resp) -> List[SerpResult]:
-        """
-        Parse results from web and news sections
-        """
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         results = []
         
-        # Parse web search results
         web_results = resp.get("web", {}).get("results", [])
         for item in web_results:
             results.append(
@@ -88,7 +65,6 @@ class BraveSearch(BaseSerper):
                 )
             )
         
-        # Parse news results
         news_results = resp.get("news", {}).get("results", [])
         for item in news_results:
             results.append(

--- a/src/surfhub/serper/duckduckgo.py
+++ b/src/surfhub/serper/duckduckgo.py
@@ -15,7 +15,7 @@ class DuckDuckGo(SerpApi):
     def __init__(self, cache=None, api_key=None):
         self.cache = cache
 
-    def get_params(self, query, page=None, num=None, options=None):
+    def get_params(self, query: str, page=None, num=None, options=None) -> dict:
         params = {
             "q": query,
             "kl": "us-en",

--- a/src/surfhub/serper/exa.py
+++ b/src/surfhub/serper/exa.py
@@ -1,6 +1,5 @@
-from typing import List, Optional
-from surfhub.serper.model import SerpResult, BaseSerper, SerpResponse
-import httpx
+from typing import List, Optional, Dict
+from surfhub.serper.model import SerpResult, BaseSerper, SerpRequestOptions
 
 
 class ExaSearch(BaseSerper):
@@ -11,7 +10,7 @@ class ExaSearch(BaseSerper):
     """
     default_api_url = "https://api.exa.ai/search"
 
-    def get_serp_params(self, query, page=None, num=None, options=None):
+    def get_serp_params(self, query: str, page=None, num=None, options: SerpRequestOptions = None) -> dict:
         params = {
             "query": query,
             "type": "auto",
@@ -30,28 +29,18 @@ class ExaSearch(BaseSerper):
 
         return params
 
-    def _headers(self):
+    @property
+    def request_method(self) -> str:
+        return "POST"
+
+    @property
+    def request_headers(self) -> Dict[str, str]:
         return {
             "x-api-key": self.api_key,
             "Content-Type": "application/json",
         }
 
-    def serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        resp = httpx.post(self.endpoint, json=params, headers=self._headers(), timeout=self.timeout)
-        resp.raise_for_status()
-        items = self.parse_result(resp.json())
-        return SerpResponse(items=items, cached=False)
-
-    async def async_serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            resp = await client.post(self.endpoint, json=params, headers=self._headers())
-            resp.raise_for_status()
-            items = self.parse_result(resp.json())
-        return SerpResponse(items=items, cached=False)
-
-    def parse_result(self, resp) -> List[SerpResult]:
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         results = resp.get("results", [])
         return [
             SerpResult(

--- a/src/surfhub/serper/google.py
+++ b/src/surfhub/serper/google.py
@@ -1,4 +1,6 @@
+from typing import List
 from .model import BaseSerper, SerpResult
+from surfhub.errors import SerpApiError
 
 class GoogleCustomSearch(BaseSerper):
     """
@@ -7,7 +9,7 @@ class GoogleCustomSearch(BaseSerper):
     
     default_api_url = "https://www.googleapis.com/customsearch/v1"
     
-    def get_serp_params(self, query, page=None, num=None, options = None):
+    def get_serp_params(self, query: str, page=None, num=None, options=None) -> dict:
         params = {
             "q": query,
         }
@@ -39,9 +41,9 @@ class GoogleCustomSearch(BaseSerper):
 
         return params
     
-    def parse_result(self, resp):
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         if 'error' in resp:
-            raise RuntimeError(resp['error']['message'])
+            raise SerpApiError(resp['error']['message'])
 
         return [
             SerpResult(

--- a/src/surfhub/serper/model.py
+++ b/src/surfhub/serper/model.py
@@ -1,7 +1,7 @@
 import abc
 import httpx
 from pydantic import BaseModel, field_validator
-from typing import Optional, List
+from typing import Optional, List, Dict
 from enum import Enum
 from surfhub.cache import Cache
 from surfhub.utils import hash_dict
@@ -80,6 +80,46 @@ class BaseSerper(SerpApi):
         
         self._api_key = api_key
         self.cache = cache
+
+    @property
+    def request_method(self) -> str:
+        return "GET"
+
+    @property
+    def request_headers(self) -> Dict[str, str]:
+        return {}
+
+    def build_response(self, items: List[SerpResult], cached: bool, resp_data=None) -> SerpResponse:
+        return SerpResponse(items=items, cached=cached)
+
+    def _cache_key(self, params: dict) -> str:
+        return hash_dict({**params, "endpoint": self.endpoint, "provider": self.__class__.__name__})
+    
+    def _fetch_and_parse(self, client: httpx.Client, params: dict, cache_key: str):
+        headers = {**self.request_headers}
+        if self.request_method == "POST":
+            resp = client.post(self.endpoint, json=params, headers=headers, timeout=self.timeout)
+        else:
+            resp = client.get(self.endpoint, params=params, headers=headers, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        items = self.parse_result(data)
+        if self.cache and cache_key:
+            self.cache.set(cache_key, items)
+        return items, data
+
+    async def _async_fetch_and_parse(self, client: httpx.AsyncClient, params: dict, cache_key: str):
+        headers = {**self.request_headers}
+        if self.request_method == "POST":
+            resp = await client.post(self.endpoint, json=params, headers=headers, timeout=self.timeout)
+        else:
+            resp = await client.get(self.endpoint, params=params, headers=headers, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        items = self.parse_result(data)
+        if self.cache and cache_key:
+            self.cache.set(cache_key, items)
+        return items, data
     
     def serp(self, query : str, page = None, num = None, options : Optional[SerpRequestOptions] = None) -> SerpResponse:
         params = self.get_serp_params(query, page, num, options)
@@ -87,20 +127,17 @@ class BaseSerper(SerpApi):
         cache_key = None
         items  = None
         cached = False
+        resp_data = None
         if self.cache:
-            cache_key = hash_dict({**params, "endpoint": self.endpoint, "provider": self.__class__.__name__})
+            cache_key = self._cache_key(params)
             items = self.cache.get(cache_key)
             cached = items is not None
         
         if items is None:
-            resp = httpx.get(self.endpoint, params=params, timeout=self.timeout)
-            resp = resp.json()
-            items = self.parse_result(resp)
+            with httpx.Client() as client:
+                items, resp_data = self._fetch_and_parse(client, params, cache_key)
         
-        if self.cache and cache_key:
-            self.cache.set(cache_key, items)
-        
-        return SerpResponse(items=items, cached=cached)
+        return self.build_response(items, cached, resp_data)
 
     async def async_serp(self, query : str, page = None, num = None, options : Optional[SerpRequestOptions] = None) -> SerpResponse:
         params = self.get_serp_params(query, page, num, options)
@@ -108,21 +145,17 @@ class BaseSerper(SerpApi):
         cache_key = None
         items = None
         cached = False
+        resp_data = None
         if self.cache:
-            cache_key = hash_dict({**params, "endpoint": self.endpoint, "provider": self.__class__.__name__})
+            cache_key = self._cache_key(params)
             items = self.cache.get(cache_key)
             cached = items is not None
         
         if items is None:
             async with httpx.AsyncClient() as client:
-                resp = await client.get(self.endpoint, params=params, timeout=self.timeout)
-                resp = resp.json()
-                items = self.parse_result(resp)
+                items, resp_data = await self._async_fetch_and_parse(client, params, cache_key)
         
-        if self.cache and cache_key:
-            self.cache.set(cache_key, items)
-        
-        return SerpResponse(items=items, cached=cached)
+        return self.build_response(items, cached, resp_data)
 
     @abc.abstractmethod
     def get_serp_params(self, query : str, page = None, num = None, options : Optional[SerpRequestOptions] = None) -> dict:

--- a/src/surfhub/serper/serpapi.py
+++ b/src/surfhub/serper/serpapi.py
@@ -1,6 +1,7 @@
 from typing import List
 from datetime import datetime
 from .model import SerpResult, BaseSerper
+from surfhub.errors import SerpApiError
 
 
 class SerpApi(BaseSerper):
@@ -10,7 +11,7 @@ class SerpApi(BaseSerper):
     
     default_api_url = "https://serpapi.com/search"
     
-    def get_serp_params(self, query, page=None, num=None, options=None):
+    def get_serp_params(self, query: str, page=None, num=None, options=None) -> dict:
         params = {
             "q": query,
             "api_key": self.api_key,
@@ -79,10 +80,10 @@ class SerpApi(BaseSerper):
             
         return params
     
-    def parse_result(self, resp) -> List[SerpResult]:
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         # Check for errors
         if "error" in resp:
-            raise Exception(f"SerpApi error: {resp['error']}")
+            raise SerpApiError(f"SerpApi error: {resp['error']}")
         
         # Parse organic results
         organic_results = resp.get("organic_results", [])

--- a/src/surfhub/serper/serper.py
+++ b/src/surfhub/serper/serper.py
@@ -1,5 +1,6 @@
 from typing import List
 from .model import SerpResult, BaseSerper
+from surfhub.errors import SerpApiError
 
 class SerperDev(BaseSerper):
     """
@@ -8,7 +9,7 @@ class SerperDev(BaseSerper):
     
     default_api_url = "https://google.serper.dev/search"
     
-    def get_serp_params(self, query, page=None, num=None, options = None):
+    def get_serp_params(self, query: str, page=None, num=None, options=None) -> dict:
         params = {
             "q": query,
             "apiKey": self.api_key
@@ -40,9 +41,9 @@ class SerperDev(BaseSerper):
             
         return params
     
-    def parse_result(self, resp) -> List[SerpResult]:
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         if resp.get('statusCode', 200) != 200:
-            raise Exception(f"Serper API error: {resp.get('message', 'Unknown error')}")
+            raise SerpApiError(f"Serper API error: {resp.get('message', 'Unknown error')}", status_code=resp.get('statusCode'))
 
         return [
             SerpResult(

--- a/src/surfhub/serper/tavily.py
+++ b/src/surfhub/serper/tavily.py
@@ -1,9 +1,10 @@
-from typing import List, Optional
-from surfhub.serper.model import SerpResult, BaseSerper, SerpResponse
-import httpx
+from typing import List, Optional, Dict
+from surfhub.serper.model import SerpResult, SerpResponse, BaseSerper, SerpRequestOptions
+
 
 class TavilySerpResponse(SerpResponse):
     answer: Optional[str] = None
+
 
 class Tavily(BaseSerper):
     """
@@ -11,7 +12,7 @@ class Tavily(BaseSerper):
     """
     default_api_url = "https://api.tavily.com/search"
 
-    def get_serp_params(self, query, page=None, num=None, options=None):
+    def get_serp_params(self, query: str, page=None, num=None, options: SerpRequestOptions = None) -> dict:
         params = {
             "query": query,
         }
@@ -19,16 +20,12 @@ class Tavily(BaseSerper):
             params["max_results"] = num
         
         if options:
-            # Handle time filtering - custom date range takes priority
             if options.date_start or options.date_end:
-                # Tavily uses start_date and end_date in YYYY-MM-DD format (same as our format!)
                 if options.date_start:
                     params["start_date"] = options.date_start
                 if options.date_end:
                     params["end_date"] = options.date_end
             elif options.time_range:
-                # Map TimeRange enum to Tavily's time_range values
-                # Tavily accepts: day, week, month, year, d, w, m, y
                 params["time_range"] = options.time_range.value
             
             if options.extra_options:
@@ -36,40 +33,26 @@ class Tavily(BaseSerper):
         
         return params
 
-    def serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        headers = {
+    @property
+    def request_method(self) -> str:
+        return "POST"
+
+    @property
+    def request_headers(self) -> Dict[str, str]:
+        return {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.api_key}",
         }
-        resp = httpx.post(self.endpoint, json=params, headers=headers, timeout=self.timeout)
-        resp.raise_for_status()
-        resp = resp.json()
-        items = self.parse_result(resp)
+
+    def build_response(self, items: List[SerpResult], cached: bool, resp_data=None) -> TavilySerpResponse:
+        answer = resp_data.get("answer", None) if resp_data else None
         return TavilySerpResponse(
             items=items,
-            cached=False,
-            answer=resp.get("answer", None),
+            cached=cached,
+            answer=answer,
         )
 
-    async def async_serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_key}",
-        }
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            resp = await client.post(self.endpoint, json=params, headers=headers)
-            resp.raise_for_status()
-            resp = resp.json()
-            items = self.parse_result(resp)
-        return TavilySerpResponse(
-            items=items,
-            cached=False,
-            answer=resp.get("answer", None),
-        )
-
-    def parse_result(self, resp) -> List[SerpResult]:
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         results = resp.get("results", [])
         return [
             SerpResult(

--- a/src/surfhub/serper/valueserp.py
+++ b/src/surfhub/serper/valueserp.py
@@ -1,6 +1,7 @@
 from typing import List
 from datetime import datetime
 from .model import SerpResult, BaseSerper
+from surfhub.errors import SerpApiError
 
 class ValueSerp(BaseSerper):
     """
@@ -9,7 +10,7 @@ class ValueSerp(BaseSerper):
     
     default_api_url = "https://api.valueserp.com/search"
     
-    def get_serp_params(self, query, page=None, num=None, options = None):
+    def get_serp_params(self, query: str, page=None, num=None, options=None) -> dict:
         params = {
             "q": query,
             "api_key": self.api_key
@@ -67,9 +68,9 @@ class ValueSerp(BaseSerper):
             
         return params
     
-    def parse_result(self, resp) -> List[SerpResult]:
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         if not resp['request_info']['success']:
-            raise Exception(resp['request_info']['message'])
+            raise SerpApiError(resp['request_info']['message'])
         
         return [
             SerpResult(

--- a/src/surfhub/serper/you.py
+++ b/src/surfhub/serper/you.py
@@ -1,6 +1,5 @@
-from typing import List
-from surfhub.serper.model import SerpResult, BaseSerper, SerpResponse
-import httpx
+from typing import List, Dict
+from surfhub.serper.model import SerpResult, BaseSerper, SerpRequestOptions
 
 
 class YouSearch(BaseSerper):
@@ -10,7 +9,7 @@ class YouSearch(BaseSerper):
     """
     default_api_url = "https://ydc-index.io/v1/search"
 
-    def get_serp_params(self, query, page=None, num=None, options=None):
+    def get_serp_params(self, query: str, page=None, num=None, options: SerpRequestOptions = None) -> dict:
         params = {
             "query": query,
         }
@@ -28,12 +27,9 @@ class YouSearch(BaseSerper):
             if options.lang:
                 params["language"] = options.lang.upper()
             
-            # Handle time filtering
             if options.date_start and options.date_end:
-                # Format: YYYY-MM-DDtoYYYY-MM-DD
                 params["freshness"] = f"{options.date_start}to{options.date_end}"
             elif options.time_range:
-                # Map TimeRange to freshness values: day, week, month, year
                 freshness_map = {
                     "d": "day",
                     "w": "week",
@@ -47,37 +43,17 @@ class YouSearch(BaseSerper):
         
         return params
 
-    def serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        headers = {
+    @property
+    def request_headers(self) -> Dict[str, str]:
+        return {
             "X-API-Key": self.api_key,
         }
-        resp = httpx.get(self.endpoint, params=params, headers=headers, timeout=self.timeout)
-        resp.raise_for_status()
-        items = self.parse_result(resp.json())
-        return SerpResponse(items=items, cached=False)
 
-    async def async_serp(self, query: str, page=None, num=None, options=None):
-        params = self.get_serp_params(query, page, num, options)
-        headers = {
-            "X-API-Key": self.api_key,
-        }
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            resp = await client.get(self.endpoint, params=params, headers=headers)
-            resp.raise_for_status()
-            items = self.parse_result(resp.json())
-        return SerpResponse(items=items, cached=False)
-
-    def parse_result(self, resp) -> List[SerpResult]:
-        """
-        Parse results from both web and news sections
-        """
+    def parse_result(self, resp: dict) -> List[SerpResult]:
         results = []
         
-        # Parse web results
         web_results = resp.get("results", {}).get("web", [])
         for item in web_results:
-            # Join snippets if available, otherwise use description
             snippet = " ".join(item.get("snippets", [])) if item.get("snippets") else item.get("description", "")
             
             results.append(
@@ -89,7 +65,6 @@ class YouSearch(BaseSerper):
                 )
             )
         
-        # Parse news results
         news_results = resp.get("results", {}).get("news", [])
         for item in news_results:
             results.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(params=["asyncio"])
+def anyio_backend(request):
+    return request.param


### PR DESCRIPTION
- Add surfhub/errors.py with ScrapingError and SerpApiError
- Fix LocalScraper.async_scrape to use httpx.AsyncClient
- Fix crawlbase.py typo and status_code type mismatch
- Fix verify_ca return type annotation
- Refactor BaseSerper with request_method/request_headers/build_response hooks
- Make Tavily, BraveSearch, YouSearch, ExaSearch use BaseSerper caching
- Add return type annotations across all modules
- Add .flake8, black/ruff/isort config to pyproject.toml
- Add GitHub Actions CI workflow
- Add tests/conftest.py to restrict anyio to asyncio backend