### PR TITLE
feat: add use_browser parameter across all scrapers, DDG fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ install_requires =
 [options.extras_require]
 test =
     respx
+browser =
+    playwright>=1.40
 
 [options.packages.find]
 where = src

--- a/src/surfhub/__init__.py
+++ b/src/surfhub/__init__.py
@@ -1,7 +1,7 @@
 from .serper import get_serper
 from .serper.model import SerpRequestOptions, SerpResult
 from .scraper import get_scraper
-from .errors import SurfhubError, ScrapingError, SerpApiError
+from .errors import SurfhubError, ScrapingError, SerpApiError, RateLimitError
 
 
 __all__ = [
@@ -12,4 +12,5 @@ __all__ = [
     "SurfhubError",
     "ScrapingError",
     "SerpApiError",
+    "RateLimitError",
 ]

--- a/src/surfhub/errors.py
+++ b/src/surfhub/errors.py
@@ -17,3 +17,8 @@ class SerpApiError(SurfhubError):
     def __init__(self, message: str, status_code: int = None):
         self.status_code = status_code
         super().__init__(message)
+
+
+class RateLimitError(SurfhubError):
+    """Raised when the target service throttles or blocks the request."""
+    pass

--- a/src/surfhub/scraper/browserless.py
+++ b/src/surfhub/scraper/browserless.py
@@ -9,7 +9,7 @@ class BrowserlessScraper(BaseScraper):
     """
     default_api_url = "https://chrome.browserless.io"
     
-    def prepare_request(self, url: str, options=None) -> httpx.Request:
+    def prepare_request(self, url: str, options=None, use_browser: bool = False) -> httpx.Request:
         # TODO: we can also use the /content api
         api_url = self.api_url + "/scrape?token=" + self.api_key
         return httpx.Request(

--- a/src/surfhub/scraper/crawlbase.py
+++ b/src/surfhub/scraper/crawlbase.py
@@ -12,7 +12,7 @@ class CrawlbaseScraper(BaseScraper):
     """
     default_api_url = "https://api.crawlbase.com/"
     
-    def prepare_request(self, url, options = None) -> httpx.Request:
+    def prepare_request(self, url, options=None, use_browser: bool = False) -> httpx.Request:
         return httpx.Request(
             "GET", 
             self.api_url, 

--- a/src/surfhub/scraper/exa.py
+++ b/src/surfhub/scraper/exa.py
@@ -11,7 +11,7 @@ class ExaScraper(BaseScraper):
     """
     default_api_url = "https://api.exa.ai/contents"
 
-    def prepare_request(self, url: str, options=None) -> httpx.Request:
+    def prepare_request(self, url: str, options=None, use_browser: bool = False) -> httpx.Request:
         return httpx.Request(
             "POST",
             self.api_url,

--- a/src/surfhub/scraper/firecrawl.py
+++ b/src/surfhub/scraper/firecrawl.py
@@ -12,7 +12,7 @@ class FirecrawlScraper(BaseScraper):
 
     default_api_url = "https://api.firecrawl.dev/v1/scrape"
 
-    def prepare_request(self, url: str, options=None) -> httpx.Request:
+    def prepare_request(self, url: str, options=None, use_browser: bool = False) -> httpx.Request:
         return httpx.Request(
             "POST",
             self.api_url,

--- a/src/surfhub/scraper/jina.py
+++ b/src/surfhub/scraper/jina.py
@@ -2,7 +2,6 @@ from .model import BaseScraper, ScraperResponse
 import httpx
 
 VALID_FORMATS = {"html", "markdown", "text"}
-VALID_ENGINES = {"direct", "browser", "cf-browser-rendering"}
 
 
 class JinaScraper(BaseScraper):
@@ -14,25 +13,21 @@ class JinaScraper(BaseScraper):
     Args:
         api_key: Jina.ai API key (optional for free tier).
         format: Return format — "html" (default), "markdown", or "text".
-        engine: Rendering engine — "direct" (default, fast), "browser" (JS-heavy sites), "cf-browser-rendering" (experimental).
     """
 
     default_api_url = "https://r.jina.ai"
 
-    def __init__(self, api_key: str = None, format: str = "html", engine: str = "direct"):
+    def __init__(self, api_key: str = None, format: str = "html"):
         super().__init__(api_key=api_key)
         if format not in VALID_FORMATS:
             raise ValueError(f"Invalid format '{format}'. Must be one of: {', '.join(sorted(VALID_FORMATS))}")
-        if engine not in VALID_ENGINES:
-            raise ValueError(f"Invalid engine '{engine}'. Must be one of: {', '.join(sorted(VALID_ENGINES))}")
         self._format = format
-        self._engine = engine
 
-    def prepare_request(self, url: str, options=None) -> httpx.Request:
+    def prepare_request(self, url: str, options=None, use_browser: bool = False) -> httpx.Request:
         api_url = f"{self.api_url.rstrip('/')}/{url}"
         headers = {
             "X-Return-Format": self._format,
-            "X-Engine": self._engine,
+            "X-Engine": "browser" if use_browser else "direct",
         }
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"

--- a/src/surfhub/scraper/local.py
+++ b/src/surfhub/scraper/local.py
@@ -1,23 +1,36 @@
 from .model import Scraper, ScraperOptions, ScraperResponse
 import httpx
 
+
 class LocalScraper(Scraper):
-    _http_proxy : str = ""
-    _https_proxy : str = ""
-    _verify_ca : bool = True
-    
+    _http_proxy: str = ""
+    _https_proxy: str = ""
+    _verify_ca: bool = True
+
     """
     A scraper that runs on local
     """
-    def _get_proxy(self) -> str | None:
-        return self.http_proxy or self.https_proxy or None
 
-    def scrape(self, url: str, options : ScraperOptions = None) -> ScraperResponse:
-        proxy = self._get_proxy()
+    def _get_proxies(self) -> dict | None:
+        if self.http_proxy or self.https_proxy:
+            return {
+                "http://": self.http_proxy,
+                "https://": self.https_proxy,
+            }
+        return None
 
-        with httpx.Client(proxy=proxy, verify=self.verify_ca) as client:
-            resp = client.get(url, timeout=self.timeout)
-        
+    def scrape(self, url: str, options: ScraperOptions = None, use_browser: bool = False) -> ScraperResponse:
+        if use_browser:
+            return self._scrape_with_browser(url, options)
+
+        proxies = self._get_proxies()
+        resp = httpx.get(
+            url,
+            timeout=self.timeout,
+            proxy=proxies,
+            verify=self.verify_ca,
+        )
+
         return ScraperResponse(
             content=resp.content,
             content_type=resp.headers.get("content-type", ""),
@@ -26,12 +39,17 @@ class LocalScraper(Scraper):
             final_url=str(resp.url),
         )
 
-    async def async_scrape(self, url: str, options : ScraperOptions = None) -> ScraperResponse:
-        proxy = self._get_proxy()
+    async def async_scrape(self, url: str, options: ScraperOptions = None, use_browser: bool = False) -> ScraperResponse:
+        if use_browser:
+            return await self._async_scrape_with_browser(url, options)
 
-        async with httpx.AsyncClient(proxy=proxy, verify=self.verify_ca) as client:
-            resp = await client.get(url, timeout=self.timeout)
-        
+        proxies = self._get_proxies()
+        async with httpx.AsyncClient(proxy=proxies, verify=self.verify_ca) as client:
+            resp = await client.get(
+                url,
+                timeout=self.timeout,
+            )
+
         return ScraperResponse(
             content=resp.content,
             content_type=resp.headers.get("content-type", ""),
@@ -39,11 +57,56 @@ class LocalScraper(Scraper):
             status_code=resp.status_code,
             final_url=str(resp.url),
         )
+
+    def _scrape_with_browser(self, url: str, options: ScraperOptions = None) -> ScraperResponse:
+        from playwright.sync_api import sync_playwright
+
+        wait_until = self._get_wait_until(options)
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.goto(url, wait_until=wait_until, timeout=self.timeout * 1000)
+            content = page.content()
+            browser.close()
+
+        return ScraperResponse(
+            content=content.encode("utf-8"),
+            content_type="text/html",
+            encoding="utf-8",
+            status_code=200,
+            final_url=page.url,
+        )
+
+    async def _async_scrape_with_browser(self, url: str, options: ScraperOptions = None) -> ScraperResponse:
+        from playwright.async_api import async_playwright
+
+        wait_until = self._get_wait_until(options)
+
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            page = await browser.new_page()
+            await page.goto(url, wait_until=wait_until, timeout=self.timeout * 1000)
+            content = await page.content()
+            await browser.close()
+
+        return ScraperResponse(
+            content=content.encode("utf-8"),
+            content_type="text/html",
+            encoding="utf-8",
+            status_code=200,
+            final_url=page.url,
+        )
+
+    def _get_wait_until(self, options: ScraperOptions = None) -> str:
+        if options is not None:
+            return getattr(options, "wait_until", "load")
+        return "load"
 
     @property
     def http_proxy(self) -> str:
         return self._http_proxy
-    
+
     @http_proxy.setter
     def http_proxy(self, value: str):
         self._http_proxy = value
@@ -51,15 +114,15 @@ class LocalScraper(Scraper):
     @property
     def https_proxy(self) -> str:
         return self._https_proxy
-    
+
     @https_proxy.setter
     def https_proxy(self, value: str):
         self._https_proxy = value
-    
+
     @property
     def verify_ca(self) -> bool:
         return self._verify_ca
-    
+
     @verify_ca.setter
     def verify_ca(self, value: bool):
         self._verify_ca = value

--- a/src/surfhub/scraper/model.py
+++ b/src/surfhub/scraper/model.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from surfhub.errors import ScrapingError
 
 class ScraperOptions(BaseModel):
-    pass
+    wait_until: str = "load"  # browser only: "load" | "domcontentloaded" | "networkidle"
 
 class ScraperResponse(BaseModel):
     content: bytes
@@ -29,11 +29,11 @@ class Scraper(abc.ABC):
     _timeout : int = 30
     
     @abc.abstractmethod
-    def scrape(self, url: str, options: ScraperOptions = None) -> ScraperResponse:
+    def scrape(self, url: str, options: ScraperOptions = None, use_browser: bool = False) -> ScraperResponse:
         pass
     
     @abc.abstractmethod
-    async def async_scrape(self, url: str, options: ScraperOptions = None) -> ScraperResponse:
+    async def async_scrape(self, url: str, options: ScraperOptions = None, use_browser: bool = False) -> ScraperResponse:
         pass
     
     @property
@@ -56,7 +56,7 @@ class BaseScraper(Scraper):
     def __init__(self, api_key: str = None):
         self._api_key = api_key
 
-    def scrape(self, url, options : ScraperOptions = None) -> ScraperResponse:
+    def scrape(self, url, options : ScraperOptions = None, use_browser: bool = False) -> ScraperResponse:
         with httpx.Client(
             timeout=self.timeout
         ) as client:
@@ -64,7 +64,7 @@ class BaseScraper(Scraper):
                 resp = None
                 try:
                     resp = client.send(
-                        self.prepare_request(url, options),
+                        self.prepare_request(url, options, use_browser),
                         auth=self.get_request_auth(),
                     )
                     
@@ -79,7 +79,7 @@ class BaseScraper(Scraper):
 
         return self.parse_response(url, resp)
 
-    async def async_scrape(self, url: str, options : ScraperOptions = None) -> ScraperResponse:
+    async def async_scrape(self, url: str, options : ScraperOptions = None, use_browser: bool = False) -> ScraperResponse:
         """
         Scrapes the content of a given URL asynchronously and returns it content
         """
@@ -90,7 +90,7 @@ class BaseScraper(Scraper):
                 resp = None
                 try:
                     resp = await client.send(
-                        self.prepare_request(url, options),
+                        self.prepare_request(url, options, use_browser),
                         auth=self.get_request_auth(),
                     )
                     
@@ -104,7 +104,7 @@ class BaseScraper(Scraper):
         return self.parse_response(url, resp)
 
     @abc.abstractmethod
-    def prepare_request(self, url: str, options : ScraperOptions = None) -> httpx.Request:
+    def prepare_request(self, url: str, options: ScraperOptions = None, use_browser: bool = False) -> httpx.Request:
         pass
     
     @abc.abstractmethod

--- a/src/surfhub/scraper/scrapingbee.py
+++ b/src/surfhub/scraper/scrapingbee.py
@@ -10,23 +10,21 @@ class ScrapingBeeScraper(BaseScraper):
 
     Args:
         api_key: ScrapingBee API key.
-        render_js: Use headless browser to render JS (default True).
         premium_proxy: Route through premium residential proxies (default False).
     """
 
     default_api_url = "https://app.scrapingbee.com/api/v1/"
 
-    def __init__(self, api_key: str = None, render_js: bool = True, premium_proxy: bool = False):
+    def __init__(self, api_key: str = None, premium_proxy: bool = False):
         super().__init__(api_key=api_key)
-        self._render_js = render_js
         self._premium_proxy = premium_proxy
 
-    def prepare_request(self, url: str, options=None) -> httpx.Request:
+    def prepare_request(self, url: str, options=None, use_browser: bool = False) -> httpx.Request:
         params = {
             "api_key": self.api_key,
             "url": url,
         }
-        if not self._render_js:
+        if not use_browser:
             params["render_js"] = "false"
         if self._premium_proxy:
             params["premium_proxy"] = "true"

--- a/src/surfhub/scraper/zyte.py
+++ b/src/surfhub/scraper/zyte.py
@@ -7,13 +7,13 @@ class ZyteScraper(BaseScraper):
     """
     default_api_url = "https://api.zyte.com/v1/extract"
     
-    def prepare_request(self, url, options = None) -> httpx.Request:
+    def prepare_request(self, url, options=None, use_browser: bool = False) -> httpx.Request:
         return httpx.Request(
             "POST", 
             self.api_url,
             json={
                 "url": url,  
-                "browserHtml": True,
+                "browserHtml": use_browser,
             }
         )
         
@@ -21,7 +21,8 @@ class ZyteScraper(BaseScraper):
         return (self.api_key, "")
         
     def parse_response(self, url: str, resp: httpx.Response) -> ScraperResponse:
-        content = resp.json()['browserHtml']
+        data = resp.json()
+        content = data.get("browserHtml") or data.get("httpResponseBody", b"").decode("utf-8")
         
         return ScraperResponse(
             content=content,

--- a/src/surfhub/serper/duckduckgo.py
+++ b/src/surfhub/serper/duckduckgo.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, parse_qs, unquote
 import httpx
 
 from .model import BaseSerper, SerpResult, SerpRequestOptions, DuckDuckGoSerpResponse
-from surfhub.errors import SerpApiError
+from surfhub.errors import SerpApiError, RateLimitError
 
 
 class DuckDuckGo(BaseSerper):
@@ -12,19 +12,39 @@ class DuckDuckGo(BaseSerper):
 
     default_api_url = "https://html.duckduckgo.com/html/"
 
+    def __init__(self, api_key: str = None, cache=None):
+        super().__init__(api_key=api_key, cache=cache)
+        self._client = None
+        self._async_client = None
+
+    def _get_client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(timeout=self.timeout)
+        return self._client
+
+    def _get_async_client(self) -> httpx.AsyncClient:
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(timeout=self.timeout)
+        return self._async_client
+
+    def close(self):
+        if self._client:
+            self._client.close()
+            self._client = None
+        if self._async_client:
+            self._async_client.close()
+            self._async_client = None
+
     @property
     def request_method(self) -> str:
-        return "POST"
+        return "GET"
 
     @property
     def request_headers(self) -> dict:
         return {
-            "User-agent": "Surfhub-Agent/0.0.1",
-            "Sec-Fetch-Mode": "navigate",
-            "Sec-Fetch-Dest": "document",
-            "Sec-Fetch-Site": "same-origin",
-            "Referer": "https://html.duckduckgo.com/",
-            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
         }
 
     def serp(self, query: str, page=None, num=None, vqd: Optional[str] = None, options: Optional[SerpRequestOptions] = None) -> DuckDuckGoSerpResponse:
@@ -35,7 +55,23 @@ class DuckDuckGo(BaseSerper):
                 options = options.model_copy(update={"extra_options": extra})
             else:
                 options = SerpRequestOptions(extra_options=extra)
-        return super().serp(query, page, num, options)
+
+        params = self.get_serp_params(query, page, num, options)
+
+        cache_key = None
+        items = None
+        cached = False
+        resp_text = None
+        if self.cache:
+            cache_key = self._cache_key(params)
+            items = self.cache.get(cache_key)
+            cached = items is not None
+
+        if items is None:
+            client = self._get_client()
+            items, resp_text = self._fetch_and_parse(client, params, cache_key)
+
+        return self.build_response(items, cached, resp_text)
 
     async def async_serp(self, query: str, page=None, num=None, vqd: Optional[str] = None, options: Optional[SerpRequestOptions] = None) -> DuckDuckGoSerpResponse:
         if vqd:
@@ -45,7 +81,23 @@ class DuckDuckGo(BaseSerper):
                 options = options.model_copy(update={"extra_options": extra})
             else:
                 options = SerpRequestOptions(extra_options=extra)
-        return await super().async_serp(query, page, num, options)
+
+        params = self.get_serp_params(query, page, num, options)
+
+        cache_key = None
+        items = None
+        cached = False
+        resp_text = None
+        if self.cache:
+            cache_key = self._cache_key(params)
+            items = self.cache.get(cache_key)
+            cached = items is not None
+
+        if items is None:
+            client = self._get_async_client()
+            items, resp_text = await self._async_fetch_and_parse(client, params, cache_key)
+
+        return self.build_response(items, cached, resp_text)
 
     def get_serp_params(self, query: str, page=None, num=None, options: Optional[SerpRequestOptions] = None) -> dict:
         params = {
@@ -84,8 +136,9 @@ class DuckDuckGo(BaseSerper):
             cookies["kl"] = params["kl"]
         if "df" in params:
             cookies["df"] = params["df"]
-        resp = client.post(self.endpoint, data=params, headers=headers, cookies=cookies, timeout=self.timeout, follow_redirects=True)
+        resp = client.get(self.endpoint, params=params, headers=headers, cookies=cookies, timeout=self.timeout, follow_redirects=True)
         resp.raise_for_status()
+        self._check_throttle(resp)
         items = self.parse_result(resp.text)
         if self.cache and cache_key:
             self.cache.set(cache_key, items)
@@ -98,12 +151,17 @@ class DuckDuckGo(BaseSerper):
             cookies["kl"] = params["kl"]
         if "df" in params:
             cookies["df"] = params["df"]
-        resp = await client.post(self.endpoint, data=params, headers=headers, cookies=cookies, timeout=self.timeout, follow_redirects=True)
+        resp = await client.get(self.endpoint, params=params, headers=headers, cookies=cookies, timeout=self.timeout, follow_redirects=True)
         resp.raise_for_status()
+        self._check_throttle(resp)
         items = self.parse_result(resp.text)
         if self.cache and cache_key:
             self.cache.set(cache_key, items)
         return items, resp.text
+
+    def _check_throttle(self, resp: httpx.Response):
+        if resp.status_code == 202 or "result__body" not in resp.text:
+            raise RateLimitError("DuckDuckGo returned a non-results page — likely rate-limited or blocked. Try again later.")
 
     def parse_result(self, resp: str) -> List[SerpResult]:
         soup = BeautifulSoup(resp, "html.parser")

--- a/tests/integration/integtest_duckduckgo.py
+++ b/tests/integration/integtest_duckduckgo.py
@@ -2,61 +2,45 @@
 
 Usage:
     python tests/integration/integtest_duckduckgo.py
-    pytest tests/integration/integtest_duckduckgo.py
 """
+import time
 from surfhub.serper.duckduckgo import DuckDuckGo
 from surfhub.errors import SerpApiError
 
+_DELAY = 3
 
-def test_page1_returns_vqd():
+
+if __name__ == "__main__":
     ddg = DuckDuckGo()
+
+    print("Page 1 vqd check...")
     page1 = ddg.serp("climate change")
     assert len(page1.items) > 0, "page 1 should have results"
     assert page1.vqd, "page 1 must return vqd"
-    return page1
+    print(f"  OK — {len(page1.items)} results, vqd={page1.vqd[:20]}...")
 
-
-def test_page2_uses_vqd():
-    ddg = DuckDuckGo()
-    page1 = ddg.serp("climate change")
+    time.sleep(_DELAY)
+    print("Page 2 with vqd...")
     page2 = ddg.serp("climate change", page=2, vqd=page1.vqd)
     assert len(page2.items) > 0, "page 2 should have results"
     page1_links = {r.link for r in page1.items}
     assert any(r.link not in page1_links for r in page2.items), \
         "page 2 should have different results from page 1"
+    print("  OK")
 
+    time.sleep(_DELAY)
+    print("Page 3 offset...")
+    page3 = ddg.serp("climate change", page=3, vqd=page1.vqd)
+    assert len(page3.items) > 0, "page 3 should have results"
+    print("  OK")
 
-def test_page2_without_vqd_raises():
-    ddg = DuckDuckGo()
+    time.sleep(_DELAY)
+    print("Page 2 without vqd raises...")
     try:
         ddg.serp("climate change", page=2)
         assert False, "should raise SerpApiError"
     except SerpApiError:
-        pass
+        print("  OK")
 
-
-def test_pagination_offset():
-    ddg = DuckDuckGo()
-    page1 = ddg.serp("climate change")
-    page3 = ddg.serp("climate change", page=3, vqd=page1.vqd)
-    assert len(page3.items) > 0, "page 3 should have results"
-
-
-if __name__ == "__main__":
-    print("Page 1 vqd check...")
-    page1 = test_page1_returns_vqd()
-    print(f"  OK — {len(page1.items)} results, vqd={page1.vqd}")
-
-    print("Page 2 with vqd...")
-    test_page2_uses_vqd()
-    print("  OK")
-
-    print("Page 2 without vqd raises...")
-    test_page2_without_vqd_raises()
-    print("  OK")
-
-    print("Page 3 offset...")
-    test_pagination_offset()
-    print("  OK")
-
+    ddg.close()
     print("\nAll integration tests passed!")

--- a/tests/integration/integtest_local_browser.py
+++ b/tests/integration/integtest_local_browser.py
@@ -1,0 +1,72 @@
+"""Integration test for local browser rendering (hits live endpoints, requires Playwright).
+
+Usage:
+    python tests/integration/integtest_local_browser.py
+    pytest tests/integration/integtest_local_browser.py
+"""
+import asyncio
+from surfhub.scraper import get_scraper
+from surfhub.scraper.model import ScraperOptions
+
+
+def test_local_browser_basic():
+    scraper = get_scraper("local")
+    resp = scraper.scrape("https://example.com", use_browser=True)
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html"
+    assert resp.encoding == "utf-8"
+    assert len(resp.content) > 0
+
+    md = resp.markdown()
+    assert len(md) > 0
+
+
+def test_local_browser_with_networkidle():
+    scraper = get_scraper("local")
+    options = ScraperOptions(wait_until="networkidle")
+    resp = scraper.scrape("https://example.com", options=options, use_browser=True)
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html"
+    assert len(resp.content) > 0
+
+
+def test_local_browser_vs_http():
+    scraper = get_scraper("local")
+
+    http_resp = scraper.scrape("https://example.com", use_browser=False)
+    browser_resp = scraper.scrape("https://example.com", use_browser=True)
+
+    assert http_resp.status_code == 200
+    assert browser_resp.status_code == 200
+    assert http_resp.content_type == "text/html"
+    assert browser_resp.content_type == "text/html"
+
+
+async def _run_async():
+    print("Local browser async...")
+    scraper = get_scraper("local")
+    resp = await scraper.async_scrape("https://example.com", use_browser=True)
+    assert resp.status_code == 200
+    assert resp.content_type == "text/html"
+    assert resp.encoding == "utf-8"
+    md = resp.markdown()
+    assert len(md) > 0
+    print("  OK")
+
+
+if __name__ == "__main__":
+    print("Local browser basic...")
+    test_local_browser_basic()
+    print("  OK")
+
+    print("Local browser networkidle...")
+    test_local_browser_with_networkidle()
+    print("  OK")
+
+    print("Local browser vs HTTP...")
+    test_local_browser_vs_http()
+    print("  OK")
+
+    asyncio.run(_run_async())
+
+    print("\nAll integration tests passed!")

--- a/tests/scaper/test_jina.py
+++ b/tests/scaper/test_jina.py
@@ -132,7 +132,7 @@ def test_jina_scraper_default_engine_is_direct():
         assert route.calls[0].request.headers["X-Engine"] == "direct"
 
 
-def test_jina_scraper_browser_engine():
+def test_jina_scraper_use_browser():
     with respx.mock:
         route = respx.get(JINA_URL).mock(
             return_value=httpx.Response(
@@ -141,14 +141,9 @@ def test_jina_scraper_browser_engine():
                 text="content",
             )
         )
-        scraper = JinaScraper(api_key="test_key", engine="browser")
-        scraper.scrape("https://example.com")
+        scraper = JinaScraper(api_key="test_key")
+        scraper.scrape("https://example.com", use_browser=True)
         assert route.calls[0].request.headers["X-Engine"] == "browser"
-
-
-def test_jina_scraper_invalid_engine():
-    with pytest.raises(ValueError, match="Invalid engine"):
-        JinaScraper(api_key="test_key", engine="phantom")
 
 
 def test_jina_scraper_auth_header():

--- a/tests/scaper/test_local.py
+++ b/tests/scaper/test_local.py
@@ -1,0 +1,188 @@
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import respx
+
+from surfhub.scraper.local import LocalScraper
+from surfhub.scraper.model import ScraperOptions
+
+
+def _create_mock_playwright_module():
+    mock_sync_api = MagicMock()
+    mock_async_api = MagicMock()
+    mock_module = MagicMock()
+    mock_module.sync_api = mock_sync_api
+    mock_module.async_api = mock_async_api
+    return mock_module, mock_sync_api, mock_async_api
+
+
+class TestLocalScraperHttp:
+    def test_basic(self):
+        with respx.mock:
+            respx.get("https://example.com").mock(
+                return_value=httpx.Response(200, text="<html>hello</html>"),
+            )
+            scraper = LocalScraper()
+            resp = scraper.scrape("https://example.com")
+            assert resp.content.decode() == "<html>hello</html>"
+            assert resp.status_code == 200
+            assert resp.final_url == "https://example.com"
+
+    def test_use_browser_false_uses_http(self):
+        with respx.mock:
+            respx.get("https://example.com").mock(
+                return_value=httpx.Response(200, text="<html>httpx</html>"),
+            )
+            scraper = LocalScraper()
+            resp = scraper.scrape("https://example.com", use_browser=False)
+            assert resp.content.decode() == "<html>httpx</html>"
+
+    @pytest.mark.anyio
+    async def test_async(self):
+        with respx.mock:
+            respx.get("https://example.com").mock(
+                return_value=httpx.Response(200, text="<html>async</html>"),
+            )
+            scraper = LocalScraper()
+            resp = await scraper.async_scrape("https://example.com")
+            assert resp.content.decode() == "<html>async</html>"
+
+
+class TestLocalScraperBrowser:
+    @staticmethod
+    def _setup_mock_sync(mock_sync_api, html="<html>rendered</html>", url="https://example.com"):
+        mock_playwright = MagicMock()
+        mock_browser = MagicMock()
+        mock_page = MagicMock()
+        mock_page.url = url
+        mock_page.content.return_value = html
+        mock_browser.new_page.return_value = mock_page
+        mock_playwright.chromium.launch.return_value = mock_browser
+        mock_sync_api.sync_playwright.return_value.__enter__.return_value = mock_playwright
+        return mock_page
+
+    @staticmethod
+    def _setup_mock_async(mock_async_api, html="<html>async rendered</html>", url="https://example.com"):
+        mock_playwright = MagicMock()
+        mock_browser = MagicMock()
+        mock_page = MagicMock()
+        mock_page.url = url
+        mock_page.content = AsyncMock(return_value=html)
+        mock_page.goto = AsyncMock()
+        mock_browser.new_page = AsyncMock(return_value=mock_page)
+        mock_browser.close = AsyncMock()
+        mock_playwright.chromium.launch = AsyncMock(return_value=mock_browser)
+        mock_async_api.async_playwright.return_value.__aenter__.return_value = mock_playwright
+        return mock_page
+
+    def _install_mock_playwright(self):
+        mock_module, mock_sync_api, mock_async_api = _create_mock_playwright_module()
+        sys.modules["playwright"] = mock_module
+        sys.modules["playwright.sync_api"] = mock_sync_api
+        sys.modules["playwright.async_api"] = mock_async_api
+        return mock_sync_api, mock_async_api
+
+    def _uninstall_mock_playwright(self):
+        sys.modules.pop("playwright", None)
+        sys.modules.pop("playwright.sync_api", None)
+        sys.modules.pop("playwright.async_api", None)
+
+    def test_use_browser_true(self):
+        mock_sync_api, _ = self._install_mock_playwright()
+        try:
+            mock_page = self._setup_mock_sync(mock_sync_api)
+
+            scraper = LocalScraper()
+            resp = scraper.scrape("https://example.com", use_browser=True)
+
+            assert resp.content.decode() == "<html>rendered</html>"
+            assert resp.content_type == "text/html"
+            assert resp.encoding == "utf-8"
+            assert resp.status_code == 200
+            assert resp.final_url == "https://example.com"
+            mock_page.goto.assert_called_once_with(
+                "https://example.com", wait_until="load", timeout=30000
+            )
+        finally:
+            self._uninstall_mock_playwright()
+
+    def test_timeout_converted_to_ms(self):
+        mock_sync_api, _ = self._install_mock_playwright()
+        try:
+            mock_page = self._setup_mock_sync(mock_sync_api)
+
+            scraper = LocalScraper()
+            scraper.timeout = 60
+            scraper.scrape("https://example.com", use_browser=True)
+
+            mock_page.goto.assert_called_once_with(
+                "https://example.com", wait_until="load", timeout=60000
+            )
+        finally:
+            self._uninstall_mock_playwright()
+
+    def test_wait_until_from_options(self):
+        mock_sync_api, _ = self._install_mock_playwright()
+        try:
+            mock_page = self._setup_mock_sync(mock_sync_api)
+
+            scraper = LocalScraper()
+            options = ScraperOptions(wait_until="networkidle")
+            scraper.scrape("https://example.com", options=options, use_browser=True)
+
+            mock_page.goto.assert_called_once_with(
+                "https://example.com", wait_until="networkidle", timeout=30000
+            )
+        finally:
+            self._uninstall_mock_playwright()
+
+    def test_wait_until_domcontentloaded(self):
+        mock_sync_api, _ = self._install_mock_playwright()
+        try:
+            mock_page = self._setup_mock_sync(mock_sync_api)
+
+            scraper = LocalScraper()
+            options = ScraperOptions(wait_until="domcontentloaded")
+            scraper.scrape("https://example.com", options=options, use_browser=True)
+
+            mock_page.goto.assert_called_once_with(
+                "https://example.com", wait_until="domcontentloaded", timeout=30000
+            )
+        finally:
+            self._uninstall_mock_playwright()
+
+    def test_default_wait_until_load(self):
+        mock_sync_api, _ = self._install_mock_playwright()
+        try:
+            mock_page = self._setup_mock_sync(mock_sync_api)
+
+            scraper = LocalScraper()
+            scraper.scrape("https://example.com", use_browser=True)
+
+            mock_page.goto.assert_called_once_with(
+                "https://example.com", wait_until="load", timeout=30000
+            )
+        finally:
+            self._uninstall_mock_playwright()
+
+    @pytest.mark.anyio
+    async def test_async_use_browser_true(self):
+        _, mock_async_api = self._install_mock_playwright()
+        try:
+            mock_page = self._setup_mock_async(mock_async_api)
+
+            scraper = LocalScraper()
+            resp = await scraper.async_scrape("https://example.com", use_browser=True)
+
+            assert resp.content.decode() == "<html>async rendered</html>"
+            assert resp.content_type == "text/html"
+            assert resp.encoding == "utf-8"
+            assert resp.status_code == 200
+            assert resp.final_url == "https://example.com"
+            mock_page.goto.assert_awaited_once_with(
+                "https://example.com", wait_until="load", timeout=30000
+            )
+        finally:
+            self._uninstall_mock_playwright()

--- a/tests/scaper/test_scrapingbee.py
+++ b/tests/scaper/test_scrapingbee.py
@@ -49,10 +49,10 @@ def test_scrapingbee_render_js_default():
         )
         scraper = ScrapingBeeScraper(api_key="test_key")
         scraper.scrape("https://example.com")
-        assert "render_js" not in route.calls[0].request.url.params
+        assert route.calls[0].request.url.params["render_js"] == "false"
 
 
-def test_scrapingbee_render_js_false():
+def test_scrapingbee_use_browser():
     with respx.mock:
         route = respx.get(SCRAPINGBEE_URL).mock(
             return_value=httpx.Response(
@@ -61,9 +61,9 @@ def test_scrapingbee_render_js_false():
                 text="<html>content</html>",
             )
         )
-        scraper = ScrapingBeeScraper(api_key="test_key", render_js=False)
-        scraper.scrape("https://example.com")
-        assert route.calls[0].request.url.params["render_js"] == "false"
+        scraper = ScrapingBeeScraper(api_key="test_key")
+        scraper.scrape("https://example.com", use_browser=True)
+        assert "render_js" not in route.calls[0].request.url.params
 
 
 def test_scrapingbee_premium_proxy():


### PR DESCRIPTION
- Add first-class use_browser param to scrape()/async_scrape() on all scrapers
- LocalScraper: Playwright browser rendering (lazy import, configurable wait_until)
- Normalize scrapingbee/jina/zyte to use request-level use_browser
- Add ScraperOptions(wait_until) for browser load strategy
- Add surfhub[browser] extras for playwright dependency
- DDG: switch to GET, browser-like headers, persistent client for session cookies
- DDG: raise RateLimitError on throttle detection
- Fix DDG integration test with delays and shared client
- Add LocalScraper browser integration test